### PR TITLE
Fixed Modal closing on error

### DIFF
--- a/new_client/src/components/events/AddEvent.jsx
+++ b/new_client/src/components/events/AddEvent.jsx
@@ -334,10 +334,9 @@ function AddEvent(props) {
       />
       <AlertUtility
         open={isError}
-        duration={1000}
+        duration={2000}
         onCloseHandler={() => {
           setIsError(false);
-          props.closeModal();
         }}
         severity="error"
         message="Oops! An error occurred. Please try again."


### PR DESCRIPTION
The modal will now still stay open if an error occurs while submitting the form. I have also changed the `error alert` duration to `2000` for better UX. 

I have tested it by intentionally creating an error by providing an incorrect endpoint to form submission. Fixes #72 