### PR TITLE
add code splitting

### DIFF
--- a/new_client/src/App.js
+++ b/new_client/src/App.js
@@ -1,31 +1,35 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import { Router, Route, Switch } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import { Provider } from "react-redux";
 import configureStore from "./store/configureStore";
 import { Box } from "@material-ui/core";
+import ProtectedRoute from "./ProtectedRoute";
 
 // Components begin here
 import Header from "./components/Header";
-import Home from "./components/Home/Home";
 import Footer from "./components/footer/Footer";
-import About from "./components/pages/About";
 import Glimpse from "./components/glimpses/Glimpse";
-
-import Blogs from "./components/blogs/Blog";
 import AddBlog from "./components/blogs/AddBlog";
-import IndividualBlog from "./components/blogs/IndividualBlog";
-
 import Signin from "./components/auth/Signin.jsx";
 import Signup from "./components/auth/Signup.jsx";
 import AddEvent from "./components/events/AddEvent";
-import EventList from "./components/events/EventList";
 import IndividualImageGalllery from "./components/glimpses/IndividualImageGalllery";
+import ResetPw from "./components/auth/ResetPw";
+import NewPw from "./components/auth/NewPw";
+import Spinner from "./components/spinner/Spinner";
 
-import ResetPw from './components/auth/ResetPw'
-import NewPw from './components/auth/NewPw'
-import ResourcePage from "./components/resources/ResourcePage";
-import ProtectedRoute from "./ProtectedRoute";
+// Lazy components start here
+const LazyHome = lazy(() => import("./components/Home/Home"));
+const LazyAbout = lazy(() => import("./components/pages/About"));
+const LazyBlogs = lazy(() => import("./components/blogs/Blog"));
+const LazyIndividualBlog = lazy(() =>
+  import("./components/blogs/IndividualBlog")
+);
+const LazyEventList = lazy(() => import("./components/events/EventList"));
+const LazyResourcePage = lazy(() =>
+  import("./components/resources/ResourcePage")
+);
 
 function App() {
   const store = configureStore();
@@ -48,29 +52,31 @@ function App() {
           </Box>
 
           <Box flexGrow={1} style={{ marginBottom: "auto", minHeight: "80vh" }}>
-            <Switch>
-              <Route exact path="/" component={Home} />
-              <Route path="/about" component={About} />
-              <Route exact path="/blogs" render={() => <Blogs />} />
-              <Route path="/signin" component={Signin} />
-              <Route path='/reset' component={ResetPw} />
-              <Route path='/newpass/:token' component={NewPw} />
-              <ProtectedRoute exact path="/addblog" component={AddBlog} />
-              <Route path="/blogs/:id" component={IndividualBlog} />
-              <ProtectedRoute path="/blog/edit/:id" component={AddBlog} />
-              <Route path="/signup" component={Signup} />
-              <Route
-                path="/glimpse/:header"
-                render={(prevProps) => (
-                  <IndividualImageGalllery {...prevProps} />
-                )}
-              />
-              <Route path="/glimpse" component={Glimpse} />
-              <Route path="/events" component={EventList} />
-              <ProtectedRoute path="/addevent" component={AddEvent} />
-              <ProtectedRoute path="/event/edit/:id" component={AddEvent} />
-              <Route path="/resources" component={ResourcePage} />
-            </Switch>
+            <Suspense fallback={<Spinner />}>
+              <Switch>
+                <Route exact path="/" component={LazyHome} />
+                <Route path="/about" component={LazyAbout} />
+                <Route exact path="/blogs" render={() => <LazyBlogs />} />
+                <Route path="/signin" component={Signin} />
+                <Route path="/reset" component={ResetPw} />
+                <Route path="/newpass/:token" component={NewPw} />
+                <ProtectedRoute exact path="/addblog" component={AddBlog} />
+                <Route path="/blogs/:id" component={LazyIndividualBlog} />
+                <ProtectedRoute path="/blog/edit/:id" component={AddBlog} />
+                <Route path="/signup" component={Signup} />
+                <Route
+                  path="/glimpse/:header"
+                  render={(prevProps) => (
+                    <IndividualImageGalllery {...prevProps} />
+                  )}
+                />
+                <Route path="/glimpse" component={Glimpse} />
+                <Route path="/events" component={LazyEventList} />
+                <ProtectedRoute path="/addevent" component={AddEvent} />
+                <ProtectedRoute path="/event/edit/:id" component={AddEvent} />
+                <Route path="/resources" component={LazyResourcePage} />
+              </Switch>
+            </Suspense>
           </Box>
 
           <Box>

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -2,14 +2,15 @@ require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
 const morgan = require("morgan");
-const helmet = require("helmet");
+// const helmet = require("helmet");
+const path = require("path")
 const routes = require("./routes");
 const config = require("./config");
 const dbconnect = require("./config/dbconnect");
 
 const app = express();
 
-app.use(helmet());
+// app.use(helmet());
 app.use(express.json({ limit: "10mb" }));
 app.use(cors());
 
@@ -23,11 +24,11 @@ routes(app);
 
 dbconnect();
 
-app.use(express.static("new_client/build"));
+app.use(express.static(path.resolve(__dirname, "../../new_client/build")));
 
-// app.get("/*", (req, res) => {
-//   res.sendFile(path.join(__dirname, "new_client/build/index.html"));
-// });
+app.get("/*", (req, res) => {
+  res.sendFile(path.resolve(__dirname, "../../new_client/build/index.html"));
+});
 
 let port = config.port;
 if (process.env.NODE_ENV === "test") port = 8001;


### PR DESCRIPTION
Introduce route based code-splitting.

Our website has many routes, but all of the JS is loaded at once. This causes some delay in the prod website to show up at initial render. By code splitting, when we hit `/`, only modules relevant to HomePage will be loaded. This, I hope, will reduce waiting time.

The choice for code splitting was based on the routes, so the following modules have independent chunks now
1. Homepage
2. AboutUs
3. EventsList
4. BlogsList.
5. ResourcesList.

I did not add the Glimpses, since we are going to remove that in a future version. If we decide that the auth pages need separate chunks as well, we may do that. 

To see this in action, before checking out this branch, run npm build from master. There will be a huge chunk of files. Next, checkout this pr and run npm build again. Notice the difference.

I have enabled some changes that will allow for a pseudo prod version of the website. After the website is built, head over to http://localhost:8000 to see the website.