### PR TITLE
[#87] Add padding to Mission Section

### DIFF
--- a/new_client/src/components/Home/components/Description/Description.scss
+++ b/new_client/src/components/Home/components/Description/Description.scss
@@ -3,11 +3,12 @@
 
 section.Description {
   margin: 0 auto;
-  padding: 0 10px;
+  padding: 0 8vw;
 
   // Mobile styles
   p {
     font-family: var(--font-family-text);
+    text-align: left; // left align on small screens
   }
 
   h2 {
@@ -143,6 +144,10 @@ section.Description {
       .description-image {
         border-radius: 15px;
       }
+    }
+    // center align on larger screens
+    p {
+      text-align: center;
     }
 
     .description-main {


### PR DESCRIPTION
Closes #87 
1. Adds padding to match the sections below
2. Text is left-aligned on smaller screens (stays centred on larger screens). This looks better.
![image](https://user-images.githubusercontent.com/47059039/107147627-0cb1c880-6975-11eb-9f0f-9ffd44f700cb.png)
