### PR TITLE
Adding workflow for react static builds

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -22,3 +22,5 @@ jobs:
           cd new_client
           npm i
           npm run build
+        env:
+          CI: false 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -1,8 +1,8 @@
 name: React app build
 on:
   push:
-  branches:
-    - master
+    branches:
+      - build-workflow
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -1,0 +1,24 @@
+name: React app build
+on:
+  push:
+  branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    
+    strategy:
+      matrix:
+        node-version: [14.x]
+        
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Creating react static build
+        run: |
+          cd new_client
+          npm i
+          npm run build

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -2,7 +2,7 @@ name: React app build
 on:
   push:
     branches:
-      - build-workflow
+      - prod
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -29,5 +29,5 @@ jobs:
         with:
           name: build
           path: new_client/build
-          retention-days: 5   
+          retention-days: 3   
           

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -23,4 +23,11 @@ jobs:
           npm i
           npm run build
         env:
-          CI: false 
+          CI: false
+      - name: Upload build folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: new_client/build
+          retention-days: 5   
+          


### PR DESCRIPTION
This github workflow will generate a static build for ```new_client``` on a push to prod branch. The build will be stored for 3 days and can be downloaded from the Actions tab or using a REST API.