### PR TITLE
Fix text  in AlumnusCardBack on Chrome, Safari

### DIFF
--- a/new_client/src/components/alumni/AlumnusCard.jsx
+++ b/new_client/src/components/alumni/AlumnusCard.jsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
     flexDirection: "column",
-    justifyContent: "end",
+    justifyContent: "flex-end",
   },
   img: {
     width: "100%",


### PR DESCRIPTION
The text of `AlumnusCardBack` appears at the bottom of the card only on Firefox (intended), but appears at the top on Chrome, Safari (unintended). This PR fixes this issue, noted in #121 . 

Fix:
`justifyContent: "flex-end"` instead of just `end`

