### PR TITLE
Made flagship event cards centre aligned

### DIFF
--- a/new_client/package-lock.json
+++ b/new_client/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "new_client",
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "1.3.13",

--- a/new_client/src/components/about-us/AboutUs.jsx
+++ b/new_client/src/components/about-us/AboutUs.jsx
@@ -192,14 +192,14 @@ export default function AboutUs() {
           </Grid>
           <Grid item xs={12}>
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4} lg={4}>
+              <Grid item xs={12} md={4} align="center">
                 <GenericDetails imgSrc={Inheritance} title="Inheritance" />
               </Grid>
-              <Grid item xs={12} md={4} lg={4}>
-                <GenericDetails imgSrc={CP} title="CP Workshop" />
+              <Grid item xs={12} md={4} align="center" >
+                <GenericDetails imgSrc={CP} title="CP Workshop"  />
               </Grid>
-              <Grid item xs={12} md={4} lg={4}>
-                <GenericDetails imgSrc={C_WS} title="C Workshop" />
+              <Grid item xs={12} md={4} align="center">
+                <GenericDetails imgSrc={C_WS} title="C Workshop"  />
               </Grid>
               <Grid item xs={12}>
                 <Typography variant="subtitle1" align="center">

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "server",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
I've tried to make the flagship events cards center-aligned. Just by adding align="center" as inline-css in COCWebsite\new_client\src\components\about-us\AboutUs.jsx path.

Also, it doesn't disturb the responsiveness of the cards. They are completely responsive and centrally aligned.

<h3>Earlier:</h3>

![image](https://user-images.githubusercontent.com/59118806/137599257-f3f3ec34-cfdf-47d8-bc91-f5b8c88707ec.png)

<h3>Now:</h3>

![image](https://user-images.githubusercontent.com/59118806/137599223-e635b188-4d82-4c04-b382-b995661c7700.png)


Fixes #144 